### PR TITLE
Feat: 사용자별 진행률 추적을 위한 loginId 처리 기능 추가

### DIFF
--- a/app.py
+++ b/app.py
@@ -40,9 +40,9 @@ TARGET_FPS_DEFAULT = float(os.environ.get("TARGET_FPS", "1.0"))         # 목표
 MAX_LAT_MS_DEFAULT = float(os.environ.get("MAX_LATENCY_MS", "2000"))    # 프레임당 최대 지연(ms)
 
 # ===== 유틸: 진행률 보고 =====
-def send_progress_to_spring(task_id, percent):
+def send_progress_to_spring(task_id, percent, login_id):
     try:
-        payload = {'taskId': task_id, 'progress': percent}
+        payload = {'taskId': task_id, 'progress': percent, 'loginId':login_id}
         headers = {'Content-Type': 'application/json'}
         requests.post(SPRING_SERVER_URL, json=payload, headers=headers, timeout=1)
     except Exception as e:
@@ -261,6 +261,7 @@ def predict_video():
     task_id = request.form.get('taskId') or str(uuid.uuid4())
     print(f"[INFO] taskId={task_id}")
 
+    login_id = request.form.get('loginId')
     mode = request.form.get('mode', 'default')  # "default" | "precision"
     use_tta = request.form.get('use_tta')
     use_illum = request.form.get('use_illum')
@@ -423,7 +424,7 @@ def predict_video():
 
             processed_frames += 1
             progress_percent = int(100 * processed_frames / max(1, expected))
-            send_progress_to_spring(task_id, progress_percent)
+            send_progress_to_spring(task_id, progress_percent,login_id)
 
         frame_idx += 1
 


### PR DESCRIPTION
## 📝 Summary
Spring 백엔드와의 연동을 위해, `/predict` 엔드포인트가 `loginId`를 수신하고 `/progress` 콜백 시 해당 `loginId`를 포함하여 백엔드가 진행률 업데이트별 사용자를 식별할 수 있도록 합니다.

## 💻 Describe your changes
  - **`/predict` 엔드포인트 수정**:
      - Spring 백엔드로부터 `multipart/form-data` 형식으로 전달되는 `loginId` 필드를 수신하도록 로직을 추가했습니다.

  - **진행률 콜백 페이로드 수정**:
      - Spring 백엔드로 진행률을 다시 POST할 때, JSON 페이로드에 `loginId`를 포함하여 전송하도록 `send_progress_to_spring` 함수를 변경했습니다.

## #️⃣ Issue number and link

## 💬 Message to the Reviewer
이 변경 사항은 Spring 백엔드에서 사용자별 실시간 피드백 기능을 구현하기 위한 전체 작업의 일부입니다. `/predict`에서 `loginId`를 수신하고, 이 ID가 진행률 콜백에 정확히 포함되어 전달되는지 프론트에서 검토해주시면 감사하겠습니다. 

